### PR TITLE
Make end callback async

### DIFF
--- a/shelltest.js
+++ b/shelltest.js
@@ -47,8 +47,8 @@ var shelltest = function() {
         if (exp.type === 'RegExp') { assert(exp.value.test(value),
           "Expected "+exp.matcher+" to match "+exp.value+" got "+value) }
       });
+      if (cb) { cb(); }
     });
-    if (cb) { cb(); }
     return this;
   };
 


### PR DESCRIPTION
This `mocha`'s test should fail

``` js
var chp = require('child_process');
var shelltest = require('shelltest');

describe("shelltest", function() {
    it("should fail when command produces another output than expected", function(done) {
        shelltest()
            .cmd('sleep 1 && echo some_string')
            .expect('stdout', 'another_string')
            .end(done)
    });
});
```

But it's passed on `master`, because callback for `end` is being invoked immediately.

I have moved invocation of callback into inside of `process.exec` handler and the test become failed. 
But I didn't manage to write a proper test for this case for now and I'm going to add such test and update this pull request then.
