### PR TITLE
test: fix not restored stub after tests

### DIFF
--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -17,6 +17,10 @@ describe('shelltest', function(){
     exec.yields({"code": 0}, "test_stdout", "test_stderr");
   });
 
+  after(function(){
+    process.exec.restore();
+  });
+
   it('should run the command', function(){
     shelltest().cmd(testCmd).end();
     expect(exec).to.have.been.calledWith(testCmd);


### PR DESCRIPTION
this is fixing surprising failing tests when using the mocha watch

```
npm test -- -w
```
