### PR TITLE
fix: allow falsy tests on stdio

### DIFF
--- a/shelltest.js
+++ b/shelltest.js
@@ -16,7 +16,7 @@ var shelltest = function() {
   };
 
   shelltest.prototype.expect = function(var1, var2) {
-    if (var2) {
+    if (arguments.length > 1) {
       this.expectations.push({ "type": var2.constructor.name, "matcher": var1, "value": var2 });
     } else {
       this.expectations.push({ "type": var1.constructor.name, "value": var1 });

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -104,6 +104,16 @@ describe('shelltest', function(){
       exec.yields(null, "test_stdout", "test_stderr");
       expect(function(){shelltest().cmd(testCmd).expect(0).end()}).to.not.throw();
     });
+
+    it('should not throw error when string stdout expectation is met and falsy', function(){
+      exec.yields(null, "", "test_stderr");
+      expect(function(){shelltest().cmd(testCmd).expect('stdout', '').end()}).to.not.throw();
+    });
+
+    it('should not throw error when string stderr expectation is met and falsy', function(){
+      exec.yields(null, "test_stdout", "");
+      expect(function(){shelltest().cmd(testCmd).expect('stderr', '').end()}).to.not.throw();
+    });
   });
 
 });


### PR DESCRIPTION
This is manly to allow one test case: when stderr or stdout match an empty string
